### PR TITLE
Added api/stocks/search request that lists stock details like implied…

### DIFF
--- a/tastyworks/dough/stocks.py
+++ b/tastyworks/dough/stocks.py
@@ -1,0 +1,26 @@
+import aiohttp
+
+from tastyworks.dough import BASE_URL
+
+"""
+Performs a stock search through dough API
+
+:param symbols: list of symbols (strings)
+:returns: list of stock details including full name, implied volatility, liquidity etc.
+:raises Exception: raises an exception when request is not 200 OK
+"""
+async def stock_search(symbols):    
+    request_url = '{}/stocks/search/'.format(
+        BASE_URL
+    )
+
+    payload = {
+        "symbols" : symbols
+    }    
+    
+    async with aiohttp.request('POST', request_url, json=payload) as resp:
+        if resp.status != 200:
+            raise Exception('Stock search failed')
+        data = await resp.json()            
+    
+    return data["stocks"]    


### PR DESCRIPTION
Basic request implementation for the /api/stocks/search. Contains stuff like implied volatility (mean and std), volatility percentile, earnings events etc. Mostly for reference and should be later refactored into a class once the architecture is solidified.