### PR TITLE
Fix order execution bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Boyan Soubachov',
     author_email='boyanvs@gmail.com',
     url='http://pypi.python.org/pypi/tastyworks/',
-    version='2.2.0',
+    version='3.0.0',
     packages=find_packages(exclude=['main.py']),
     python_requires='>= 3.6.0',
     description='Tastyworks (unofficial) API',

--- a/tastyworks/example.py
+++ b/tastyworks/example.py
@@ -33,8 +33,9 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     orders = await Order.get_remote_orders(session, acct)
     LOGGER.info('Number of active orders: %s', len(orders))
 
+    # Execute an order
+
     details = OrderDetails(
-        underlying_symbol='AKS',
         type=OrderType.LIMIT,
         price=400,
         price_effect=OrderPriceEffect.CREDIT)
@@ -43,7 +44,7 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     opt = Option(
         ticker='AKS',
         quantity=1,
-        expiry=date(2018, 8, 10),
+        expiry=date(2018, 8, 31),
         strike=3.5,
         option_type=OptionType.CALL,
         underlying_type=UnderlyingType.EQUITY
@@ -74,6 +75,8 @@ def main():
 
     try:
         loop.run_until_complete(main_loop(tasty_client, streamer))
+    except Exception as e:
+        LOGGER.exception('Exception in main loop')
     finally:
         # find all futures/tasks still running and wait for them to finish
         pending_tasks = [

--- a/tastyworks/models/option.py
+++ b/tastyworks/models/option.py
@@ -56,7 +56,7 @@ class Option(object):
 
     def to_tasty_json(self):
         res = {
-            'instrument-type': self.underlying_type.value,
+            'instrument-type': f'{self.underlying_type.value} Option',
             'symbol': self.get_occ2010_symbol(),
             'quantity': self.quantity
         }

--- a/tastyworks/models/order.py
+++ b/tastyworks/models/order.py
@@ -33,7 +33,6 @@ class OrderStatus(Enum):
 
 @dataclass
 class OrderDetails(object):
-    underlying_symbol: str
     type: OrderType = None
     time_in_force: str = 'Day'
     price: float = None

--- a/tests/models/test_option.py
+++ b/tests/models/test_option.py
@@ -68,3 +68,12 @@ class TestOptionModel(unittest.TestCase):
     def test_get_underlying_type_string(self):
         res = self.test_option._get_underlying_type_string(UnderlyingType.EQUITY)
         self.assertEqual(res, 'Equity Option')
+
+    def test_to_tasty_json(self):
+        res = self.test_option.to_tasty_json()
+        expected_result = {
+            'instrument-type': 'Equity Option',
+            'symbol': 'AKS   180810C00003500',
+            'quantity': 1
+        }
+        self.assertDictEqual(res, expected_result)

--- a/tests/models/test_trading_account.py
+++ b/tests/models/test_trading_account.py
@@ -1,0 +1,44 @@
+import datetime
+import unittest
+
+from tastyworks.models import option, order, underlying, trading_account
+
+
+class TestTradingAccount(unittest.TestCase):
+    def setUp(self):
+        self.order_details = order.OrderDetails(
+            type=order.OrderType.LIMIT,
+            price=400,
+            price_effect=order.OrderPriceEffect.CREDIT,
+        )
+        self.order_details.legs = [
+            option.Option(
+                ticker='AKS',
+                expiry=datetime.date(2018, 8, 31),
+                strike=3.5,
+                option_type=option.OptionType.CALL,
+                underlying_type=underlying.UnderlyingType.EQUITY,
+                quantity=1
+            )
+        ]
+        self.test_order = order.Order(self.order_details)
+
+    def test_get_execute_order_json(self):
+        res = trading_account._get_execute_order_json(self.test_order)
+        expected_result = {
+            'source': 'WBT',
+            'order-type': 'Limit',
+            'price': '400.00',
+            'price-effect': 'Credit',
+            'time-in-force': 'Day',
+            'legs': [
+                {
+                    'instrument-type': 'Equity Option',
+                    'symbol': 'AKS   180831C00003500',
+                    'quantity': 1,
+                    'action': 'Sell to Open'
+                }
+            ]
+        }
+
+        self.assertDictEqual(res, expected_result)


### PR DESCRIPTION
# Problem addressed
Orders weren't executing.

# Solution

An incomplete `instrument` field was being sent to tastyworks. This has been fixed.

# Checklist

- PR commits have been squashed
- All tests pass
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
