### PR TITLE
Refactoring + fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,11 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# idea
+.idea
+*.iml
+*.ipr
+
 .vscode/
 
 main.py

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Boyan Soubachov',
     author_email='boyanvs@gmail.com',
     url='http://pypi.python.org/pypi/tastyworks/',
-    version='3.0.1',
+    version='3.1.0',
     packages=find_packages(exclude=['main.py']),
     python_requires='>= 3.6.0',
     description='Tastyworks (unofficial) API',

--- a/tastyworks/dough/watchlists.py
+++ b/tastyworks/dough/watchlists.py
@@ -41,6 +41,8 @@ class WatchlistGroup(object):
             wlist.slug = entry['slug']
             self.watchlists[wlist.slug] = wlist
 
+        return self
+
 
 def get_all_watchlists():
-    return WatchlistGroup.load_watchlists()
+    return WatchlistGroup().load_watchlists()

--- a/tastyworks/example.py
+++ b/tastyworks/example.py
@@ -1,6 +1,8 @@
 import asyncio
+import calendar
 import logging
-from datetime import date
+from datetime import date, timedelta
+from decimal import Decimal
 
 from tastyworks.models import option_chain, underlying
 from tastyworks.models.option import Option, OptionType
@@ -37,15 +39,15 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
 
     details = OrderDetails(
         type=OrderType.LIMIT,
-        price=400,
+        price=Decimal(400),
         price_effect=OrderPriceEffect.CREDIT)
     new_order = Order(details)
 
     opt = Option(
         ticker='AKS',
         quantity=1,
-        expiry=date(2018, 10, 19),
-        strike=3.0,
+        expiry=get_third_friday(date.today()),
+        strike=Decimal(3),
         option_type=OptionType.CALL,
         underlying_type=UnderlyingType.EQUITY
     )
@@ -66,6 +68,19 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
         LOGGER.info('Received item: %s' % item.data)
 
 
+def get_third_friday(d):
+    s = date(d.year, d.month, 15)
+    candidate = s + timedelta(days=(calendar.FRIDAY - s.weekday()) % 7)
+
+    # This month's third friday passed
+    if candidate < d:
+        candidate += timedelta(weeks=4)
+        if candidate.day < 15:
+            candidate += timedelta(weeks=1)
+
+    return candidate
+
+
 def main():
     tasty_client = tasty_session.create_new_session('your_username', 'your_password_here')
 
@@ -75,7 +90,7 @@ def main():
 
     try:
         loop.run_until_complete(main_loop(tasty_client, streamer))
-    except Exception as e:
+    except Exception:
         LOGGER.exception('Exception in main loop')
     finally:
         # find all futures/tasks still running and wait for them to finish

--- a/tastyworks/models/option.py
+++ b/tastyworks/models/option.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from dataclasses import dataclass
 
+from tastyworks.models.security import Security
 from tastyworks.models.underlying import UnderlyingType
 
 
@@ -13,7 +14,7 @@ class OptionType(Enum):
 
 
 @dataclass
-class Option(object):
+class Option(Security):
     ticker: str
     expiry: date
     strike: Decimal
@@ -40,14 +41,14 @@ class Option(object):
         return res
 
     def get_dxfeed_symbol(self):
-        if self.strike.is_integer():
-            strike_str = '{0:.0f}'.format(int(self.strike))
+        if self.strike % 1 == 0:
+            strike_str = '{0:.0f}'.format(self.strike)
         else:
             strike_str = '{0:.2f}'.format(self.strike)
             if strike_str[-1] == '0':
                 strike_str = strike_str[:-1]
 
-        res = '{ticker}{exp_date}{type}{strike}'.format(
+        res = '.{ticker}{exp_date}{type}{strike}'.format(
             ticker=self.ticker,
             exp_date=self.expiry.strftime('%y%m%d'),
             type=self.option_type.value,

--- a/tastyworks/models/option_chain.py
+++ b/tastyworks/models/option_chain.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Dict, List
+from typing import Dict
 
 import aiohttp
 
@@ -49,7 +49,7 @@ class OptionChain(object):
         return self._get_filter_strategy('expiry')
 
 
-async def get_option_chain(session, underlying: Underlying, expiration: date = None) -> List[Option]:
+async def get_option_chain(session, underlying: Underlying, expiration: date = None) -> OptionChain:
     LOGGER.debug('Getting options chain for ticker: %s', underlying.ticker)
     data = await _get_tasty_option_chain_data(session, underlying)
     res = []
@@ -74,7 +74,7 @@ async def get_option_chain(session, underlying: Underlying, expiration: date = N
     return OptionChain(res)
 
 
-async def _get_tasty_option_chain_data(session, underlying) -> List[Dict]:
+async def _get_tasty_option_chain_data(session, underlying) -> Dict:
     async with aiohttp.request(
             'GET',
             f'{session.API_url}/option-chains/{underlying.ticker}/nested',

--- a/tastyworks/models/session.py
+++ b/tastyworks/models/session.py
@@ -33,13 +33,13 @@ class TastyAPISession(object):
         self.logged_in = True
         self.logged_in_at = datetime.datetime.now()
         self.session_token = resp.json()['data']['session-token']
-        self._validate_session(self.session_token)
+        self._validate_session()
         return self.session_token
 
     def is_active(self):
-        return self._validate_session(self.session_token)
+        return self._validate_session()
 
-    def _validate_session(self, session_token):
+    def _validate_session(self):
         resp = requests.post(f'{self.API_url}/sessions/validate', headers=self.get_request_headers())
         if resp.status_code != 201:
             self.logged_in = False

--- a/tastyworks/streamer.py
+++ b/tastyworks/streamer.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import threading
+from typing import List
 
 import requests
 import websockets
@@ -94,7 +95,7 @@ class DataStreamer(object):
             }
         }])
 
-    def _get_connect_msg(self, advice=True) -> str:
+    def _get_connect_msg(self, advice=True) -> List:
         if advice:
             msg = [
                 {

--- a/tests/models/test_option.py
+++ b/tests/models/test_option.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import date
+from decimal import Decimal
 
 from tastyworks.models.option import Option, OptionType
 from tastyworks.models.underlying import UnderlyingType
@@ -11,7 +12,7 @@ class TestOptionModel(unittest.TestCase):
             ticker='AKS',
             quantity=1,
             expiry=date(2018, 8, 10),
-            strike=3.5,
+            strike=Decimal('3.5'),
             option_type=OptionType.CALL,
             underlying_type=UnderlyingType.EQUITY
         )
@@ -57,7 +58,7 @@ class TestOptionModel(unittest.TestCase):
         self.assertEqual(expected_result, res)
 
     def test_get_dxfeed_symbol(self):
-        expected_result = 'AKS180810C3.5'
+        expected_result = '.AKS180810C3.5'
         result = self.test_option.get_dxfeed_symbol()
         self.assertEqual(result, expected_result)
 

--- a/tests/models/test_option_chain.py
+++ b/tests/models/test_option_chain.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import date
+from decimal import Decimal
 
 from tastyworks.models import option, option_chain, underlying
 
@@ -9,17 +10,16 @@ class TestOptionChain(unittest.TestCase):
         options = [option.Option(
             ticker='AKS',
             expiry=date(2018, 1, 21),
-            strike=3.5,
+            strike=Decimal('3.5'),
+            option_type=option.OptionType.PUT,
+            underlying_type=underlying.UnderlyingType.EQUITY
+        ), option.Option(
+            ticker='AKS',
+            expiry=date(2018, 2, 21),
+            strike=Decimal(4),
             option_type=option.OptionType.PUT,
             underlying_type=underlying.UnderlyingType.EQUITY
         )]
-        options.append(option.Option(
-            ticker='AKS',
-            expiry=date(2018, 2, 21),
-            strike=4,
-            option_type=option.OptionType.PUT,
-            underlying_type=underlying.UnderlyingType.EQUITY
-        ))
 
         self.option_chain = option_chain.OptionChain(options)
 
@@ -35,7 +35,7 @@ class TestOptionChain(unittest.TestCase):
         self.option_chain.options.append(option.Option(
             ticker='AKS',
             expiry=date(2018, 4, 21),
-            strike=3.5,
+            strike=Decimal('3.5'),
             option_type=option.OptionType.PUT,
             underlying_type=underlying.UnderlyingType.EQUITY
         ))
@@ -52,7 +52,7 @@ class TestOptionChain(unittest.TestCase):
         self.option_chain.options.append(option.Option(
             ticker='AKS',
             expiry=date(2018, 2, 21),
-            strike=3.5,
+            strike=Decimal('3.5'),
             option_type=option.OptionType.PUT,
             underlying_type=underlying.UnderlyingType.EQUITY
         ))

--- a/tests/models/test_trading_account.py
+++ b/tests/models/test_trading_account.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+from decimal import Decimal
 
 from tastyworks.models import option, order, underlying, trading_account
 
@@ -8,14 +9,14 @@ class TestTradingAccount(unittest.TestCase):
     def setUp(self):
         self.order_details = order.OrderDetails(
             type=order.OrderType.LIMIT,
-            price=400,
+            price=Decimal(400),
             price_effect=order.OrderPriceEffect.CREDIT,
         )
         self.order_details.legs = [
             option.Option(
                 ticker='AKS',
                 expiry=datetime.date(2018, 8, 31),
-                strike=3.5,
+                strike=Decimal('3.5'),
                 option_type=option.OptionType.CALL,
                 underlying_type=underlying.UnderlyingType.EQUITY,
                 quantity=1


### PR DESCRIPTION
# Problem addressed

1) get_all_watchlists returns None
2) warnings that Option is not a Security
3) if option strike is used as Decimal, got error that is_integer is not available
4) type checking: some return types do not correspond to what is actually returned, eg. List[Option] instead of OptionChain
5) example is using hardcoded date, after this date the Option will not be available
6) option DX symbol must be prefixed with '.' 

# Solution
1) Fixed
2) Option extends Security
3) using decimal % 1 == 0 to determine if it is an integer
4) fixed return types to match al return values
5) using closest third friday
6) option DX symbol is now  prefixed with '.' - fixed
streamer did not work for my without the dot, it works with the dot. 

you also have it in your example.py:
```
sub_values = {
     "Greeks": [
         ".VIX180718C21",
         ".YUM180518C95"
     ]
}

```

# Checklist

- PR commits have been squashed
- All tests pass
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)


