### PR TITLE
add other time in force types to order details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All important and notable changes will be documented here.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.2] - 2019-02-19
+
+### Added
+- The `time-in-force` and `gtc-date` properties to the OrderDetails object
+
+### Changed
+- Example script now uses env vars for TastyWorks username/password instead of hard-coding values.
+
 ## [3.1.1] - 2019-01-16
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Boyan Soubachov',
     author_email='boyanvs@gmail.com',
     url='http://pypi.python.org/pypi/tastyworks/',
-    version='3.1.1',
+    version='3.1.2',
     packages=find_packages(exclude=['main.py']),
     python_requires='>= 3.6.0',
     description='Tastyworks (unofficial) API',

--- a/tastyworks/example.py
+++ b/tastyworks/example.py
@@ -1,6 +1,7 @@
 import asyncio
 import calendar
 import logging
+from os import environ
 from datetime import date, timedelta
 from decimal import Decimal
 
@@ -82,7 +83,7 @@ def get_third_friday(d):
 
 
 def main():
-    tasty_client = tasty_session.create_new_session('your_username', 'your_password_here')
+    tasty_client = tasty_session.create_new_session(environ['TW_USER'], environ['TW_PASSWORD'])
 
     streamer = DataStreamer(tasty_client)
     LOGGER.info('Streamer token: %s' % streamer.get_streamer_token())

--- a/tastyworks/models/order.py
+++ b/tastyworks/models/order.py
@@ -44,7 +44,7 @@ class TimeInForce(Enum):
 class OrderDetails(object):
     type: OrderType = None
     time_in_force: TimeInForce = TimeInForce.DAY
-    gtc_date: str = None
+    gtc_date: datetime = None
     price: Decimal = None
     price_effect: OrderPriceEffect = None
     status: OrderStatus = None

--- a/tastyworks/models/trading_account.py
+++ b/tastyworks/models/trading_account.py
@@ -102,7 +102,7 @@ def _get_execute_order_json(order: Order):
     }
 
     if order.details.gtc_date:
-        order_json['gtc-date'] = order.details.gtc_date
+        order_json['gtc-date'] = order.details.gtc_date.strftime('%Y-%m-%d')
 
     return order_json
 

--- a/tastyworks/models/trading_account.py
+++ b/tastyworks/models/trading_account.py
@@ -108,10 +108,10 @@ def _get_execute_order_json(order: Order):
 
 
 def _get_legs_request_data(order):
-        res = []
-        order_effect = order.details.price_effect
-        order_effect_str = 'Sell to Open' if order_effect == OrderPriceEffect.CREDIT else 'Buy to Open'
-        for leg in order.details.legs:
-            leg_dict = {**leg.to_tasty_json(), 'action': order_effect_str}
-            res.append(leg_dict)
-        return res
+    res = []
+    order_effect = order.details.price_effect
+    order_effect_str = 'Sell to Open' if order_effect == OrderPriceEffect.CREDIT else 'Buy to Open'
+    for leg in order.details.legs:
+        leg_dict = {**leg.to_tasty_json(), 'action': order_effect_str}
+        res.append(leg_dict)
+    return res

--- a/tastyworks/models/trading_account.py
+++ b/tastyworks/models/trading_account.py
@@ -92,14 +92,19 @@ class TradingAccount(object):
 
 
 def _get_execute_order_json(order: Order):
-    return {
+    order_json = {
         'source': order.details.source,
         'order-type': order.details.type.value,
         'price': '{:.2f}'.format(order.details.price),
         'price-effect': order.details.price_effect.value,
-        'time-in-force': order.details.time_in_force,
+        'time-in-force': order.details.time_in_force.value,
         'legs': _get_legs_request_data(order)
     }
+
+    if order.details.gtc_date:
+        order_json['gtc-date'] = order.details.gtc_date
+
+    return order_json
 
 
 def _get_legs_request_data(order):

--- a/tests/models/test_order.py
+++ b/tests/models/test_order.py
@@ -1,6 +1,8 @@
 import unittest
 from tastyworks.models import order
 
+DATE = '2019-02-12'
+
 
 class TestOrderStatus(unittest.TestCase):
     def setUp(self):
@@ -18,3 +20,11 @@ class TestOrderStatus(unittest.TestCase):
         res = order.Order.from_dict(self.json_input)
         self.assertEqual(res.details.type, order.OrderType.MARKET)
         self.assertIsNone(res.details.price)
+
+    def test_from_dict_when_gtd(self):
+        self.json_input['time-in-force'] = 'GTD'
+        self.json_input['gtc-date'] = DATE
+        res = order.Order.from_dict(self.json_input)
+        self.assertEqual(res.details.type, order.OrderType.MARKET)
+        self.assertEqual(res.details.time_in_force, order.TimeInForce.GTD.value)
+        self.assertEqual(res.details.gtc_date, DATE)

--- a/tests/models/test_trading_account.py
+++ b/tests/models/test_trading_account.py
@@ -13,7 +13,7 @@ def build_default_order(time_in_force=order.TimeInForce.DAY):
         price=Decimal(400),
         price_effect=order.OrderPriceEffect.CREDIT,
         time_in_force=time_in_force,
-        gtc_date=GTC_DATE if time_in_force == order.TimeInForce.GTD else None
+        gtc_date=datetime.datetime(2019, 2, 12) if time_in_force == order.TimeInForce.GTD else None
     )
     order_details.legs = [
         option.Option(

--- a/tests/models/test_trading_account.py
+++ b/tests/models/test_trading_account.py
@@ -4,34 +4,62 @@ from decimal import Decimal
 
 from tastyworks.models import option, order, underlying, trading_account
 
+GTC_DATE = '2019-02-12'
+
+
+def build_default_order(time_in_force=order.TimeInForce.DAY):
+    order_details = order.OrderDetails(
+        type=order.OrderType.LIMIT,
+        price=Decimal(400),
+        price_effect=order.OrderPriceEffect.CREDIT,
+        time_in_force=time_in_force,
+        gtc_date=GTC_DATE if time_in_force == order.TimeInForce.GTD else None
+    )
+    order_details.legs = [
+        option.Option(
+            ticker='AKS',
+            expiry=datetime.date(2018, 8, 31),
+            strike=Decimal('3.5'),
+            option_type=option.OptionType.CALL,
+            underlying_type=underlying.UnderlyingType.EQUITY,
+            quantity=1
+        )
+    ]
+    return order.Order(order_details)
+
 
 class TestTradingAccount(unittest.TestCase):
-    def setUp(self):
-        self.order_details = order.OrderDetails(
-            type=order.OrderType.LIMIT,
-            price=Decimal(400),
-            price_effect=order.OrderPriceEffect.CREDIT,
-        )
-        self.order_details.legs = [
-            option.Option(
-                ticker='AKS',
-                expiry=datetime.date(2018, 8, 31),
-                strike=Decimal('3.5'),
-                option_type=option.OptionType.CALL,
-                underlying_type=underlying.UnderlyingType.EQUITY,
-                quantity=1
-            )
-        ]
-        self.test_order = order.Order(self.order_details)
-
     def test_get_execute_order_json(self):
-        res = trading_account._get_execute_order_json(self.test_order)
+        test_order = build_default_order()
+        res = trading_account._get_execute_order_json(test_order)
         expected_result = {
             'source': 'WBT',
             'order-type': 'Limit',
             'price': '400.00',
             'price-effect': 'Credit',
             'time-in-force': 'Day',
+            'legs': [
+                {
+                    'instrument-type': 'Equity Option',
+                    'symbol': 'AKS   180831C00003500',
+                    'quantity': 1,
+                    'action': 'Sell to Open'
+                }
+            ]
+        }
+
+        self.assertDictEqual(res, expected_result)
+
+    def test_get_execute_order_json_when_gtd(self):
+        test_order = build_default_order(order.TimeInForce.GTD)
+        res = trading_account._get_execute_order_json(test_order)
+        expected_result = {
+            'source': 'WBT',
+            'order-type': 'Limit',
+            'price': '400.00',
+            'price-effect': 'Credit',
+            'time-in-force': 'GTD',
+            'gtc-date': GTC_DATE,
             'legs': [
                 {
                     'instrument-type': 'Equity Option',


### PR DESCRIPTION
# Problem addressed

The problem/issue addressed by this PR is https://github.com/boyan-soubachov/tastyworks_api/issues/8. Adding more time in force options like GTC and GTD. 

# Solution

Added a time-in-force Enum property to the OrderDetails object. Also add a gtc-date which is only relevant when using the GTD option. Made sure to check the payload the tastyworks api send when using this time in force option. 

# Checklist

- PR commits have been squashed
- All tests pass
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
