### PR TITLE
Add additional message types for dxFeed streamer /service/sub channel

### DIFF
--- a/tastyworks/dxfeed/mapper.py
+++ b/tastyworks/dxfeed/mapper.py
@@ -23,5 +23,8 @@ def map_message(message):
         res = summary.Summary(data=message)
     elif profile.Profile.DXFEED_TEXT == msg_type:
         res = profile.Profile(data=message)
+    else:
+        LOGGER.warning("Unknown message type received from streamer: {}".format(message))
+        res = [{'warning': 'Unknown message type received', 'message': message}]
 
     return res

--- a/tastyworks/dxfeed/mapper.py
+++ b/tastyworks/dxfeed/mapper.py
@@ -1,6 +1,6 @@
 import logging
 
-from tastyworks.dxfeed import greeks, quote
+from tastyworks.dxfeed import greeks, quote, trade, summary, profile
 
 LOGGER = logging.getLogger(__name__)
 KEY_MAP = {}
@@ -17,5 +17,11 @@ def map_message(message):
         res = quote.Quote(data=message)
     elif greeks.Greeks.DXFEED_TEXT == msg_type:
         res = greeks.Greeks(data=message)
+    elif trade.Trade.DXFEED_TEXT == msg_type:
+        res = trade.Trade(data=message)
+    elif summary.Summary.DXFEED_TEXT == msg_type:
+        res = summary.Summary(data=message)
+    elif profile.Profile.DXFEED_TEXT == msg_type:
+        res = profile.Profile(data=message)
 
     return res

--- a/tastyworks/dxfeed/profile.py
+++ b/tastyworks/dxfeed/profile.py
@@ -1,0 +1,8 @@
+from tastyworks.dxfeed.mapped_item import MappedItem
+
+
+class Profile(MappedItem):
+    DXFEED_TEXT = 'Profile'
+
+    def __init__(self, data=None):
+        super().__init__(data=data)

--- a/tastyworks/dxfeed/summary.py
+++ b/tastyworks/dxfeed/summary.py
@@ -1,0 +1,8 @@
+from tastyworks.dxfeed.mapped_item import MappedItem
+
+
+class Summary(MappedItem):
+    DXFEED_TEXT = 'Summary'
+
+    def __init__(self, data=None):
+        super().__init__(data=data)

--- a/tastyworks/dxfeed/trade.py
+++ b/tastyworks/dxfeed/trade.py
@@ -1,0 +1,13 @@
+from tastyworks.dxfeed.mapped_item import MappedItem
+import datetime
+
+
+class Trade(MappedItem):
+    DXFEED_TEXT = 'Trade'
+
+    def _process_fields(self, data_dict: dict):
+        data_dict['eventTime'] = datetime.datetime.fromtimestamp(data_dict['eventTime'] / 1000_000_000)
+        return data_dict
+
+    def __init__(self, data=None):
+        super().__init__(data=data)

--- a/tastyworks/dxfeed/trade.py
+++ b/tastyworks/dxfeed/trade.py
@@ -6,7 +6,7 @@ class Trade(MappedItem):
     DXFEED_TEXT = 'Trade'
 
     def _process_fields(self, data_dict: dict):
-        data_dict['eventTime'] = datetime.datetime.fromtimestamp(data_dict['eventTime'] / 1000_000_000)
+        data_dict['time'] = datetime.datetime.fromtimestamp(data_dict['time'] / 1000_000_000)
         return data_dict
 
     def __init__(self, data=None):


### PR DESCRIPTION
# Problem addressed

This PR adds three additional message types for dxFeed's /service/sub channel: `trade`, `summary`, and `profile`.

I also included a default case for `tastyworks.dxfeed.map_message`. If a message type that did not match either `Quote` or `Greek`, there is a case of use before assignment for the variable `res`. Where `res` is returned from the function but not yet assigned anything.

The default case prints a warning message to logger and assigns a list(dict()) message to res that includes a brief warning message as well as the contents of the message.

`trade` includes the following keys:
```
0: "eventSymbol"
1: "eventTime"
2: "time"
3: "timeNanoPart"
4: "sequence"
5: "exchangeCode"
6: "price"
7: "size"
8: "dayVolume"
9: "dayTurnover"
10: "tickDirection"
11: "extendedTradingHours"
```

`summary` includes the following keys:
```
0: "eventSymbol"
1: "eventTime"
2: "dayId"
3: "dayOpenPrice"
4: "dayHighPrice"
5: "dayLowPrice"
6: "dayClosePrice"
7: "dayClosePriceType"
8: "prevDayId"
9: "prevDayClosePrice"
10: "prevDayClosePriceType"
11: "prevDayVolume"
12: "openInterest"
```

`profile` includes the following keys:
```
0: "eventSymbol"
1: "eventTime"
2: "description"
3: "shortSaleRestriction"
4: "tradingStatus"
5: "statusReason"
6: "haltStartTime"
7: "haltEndTime"
8: "highLimitPrice"
9: "lowLimitPrice"
```

# Solution

Implement `trade.py`, `summary.py`, and `profile.py` as closely as possible to `quote.py`/`greeks.py`.

Add `else:` statement to `map_message()` function when received message does not match any comparisons in if/elif statement.

# Checklist

- PR commits have been squashed
- All tests pass
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
