### PR TITLE
updated watchlists endpoint

### DIFF
--- a/tastyworks/models/watchlists.py
+++ b/tastyworks/models/watchlists.py
@@ -30,7 +30,6 @@ class WatchlistGroup(object):
         Args:
             session (TastyAPISession): The session to use.
         """
-
         request_url = '{}/public-watchlists'.format(
             session.API_url
         )

--- a/tastyworks/models/watchlists.py
+++ b/tastyworks/models/watchlists.py
@@ -23,7 +23,9 @@ class WatchlistGroup(object):
 
     async def load_watchlists(self, session):
         """
-        Gets watchlists
+        Get's a users public watchlists.
+        
+        For user created watchlists use '/watchlists' instead.
 
         Args:
             session (TastyAPISession): The session to use.
@@ -32,7 +34,6 @@ class WatchlistGroup(object):
         request_url = '{}/public-watchlists'.format(
             session.API_url
         )
-        # /watchlists is the end point for user created watchlists
 
         async with aiohttp.request('GET', request_url) as resp:
             if resp.status != 200:

--- a/tastyworks/models/watchlists.py
+++ b/tastyworks/models/watchlists.py
@@ -1,7 +1,5 @@
 import aiohttp
 
-from tastyworks.dough import BASE_URL
-
 
 class Watchlist(object):
     def __init__(self, name=None, slug=None):
@@ -23,10 +21,18 @@ class WatchlistGroup(object):
     def __init__(self):
         self.watchlists = {}
 
-    async def load_watchlists(self):
-        request_url = '{}/public_watchlists?include_synthetic=true'.format(
-            BASE_URL
+    async def load_watchlists(self, session):
+        """
+        Gets watchlists
+
+        Args:
+            session (TastyAPISession): The session to use.
+        """
+
+        request_url = '{}/public-watchlists'.format(
+            session.API_url
         )
+        # /watchlists is the end point for user created watchlists
 
         async with aiohttp.request('GET', request_url) as resp:
             if resp.status != 200:


### PR DESCRIPTION
removed depracated watchlist

Watchlists URI was deprecated from Dough and is now served under the TastyWorks API.

# Solution

- Moved watchlists from Dough package to ./TastyWorks/Models
- Updated URI
- Updated class method to accept a TastyWorks session (auth required)

# Checklist

- PR commits have been squashed
Yes
- All tests pass
I'm not adept enough to know what I'm doing here
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
Yes