### PR TITLE
add transaction history pagination support

### DIFF
--- a/tastyworks/example.py
+++ b/tastyworks/example.py
@@ -1,6 +1,7 @@
 import asyncio
 import calendar
 import logging
+
 from os import environ
 from datetime import date, timedelta
 from decimal import Decimal
@@ -14,6 +15,7 @@ from tastyworks.models.trading_account import TradingAccount
 from tastyworks.models.underlying import UnderlyingType
 from tastyworks.streamer import DataStreamer
 from tastyworks.tastyworks_api import tasty_session
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,15 +31,39 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
         "Quote": ["/ES"]
     }
 
-    accounts = await TradingAccount.get_remote_accounts(session)
-    acct = accounts[0]
-    LOGGER.info('Accounts available: %s', accounts)
+    accounts = await TradingAccount.get_accounts(session)
+    account_nums = list(map(lambda x: x.account_number, accounts))
+    print(f'Accounts available: {account_nums}')
+
+    for acct in accounts:
+        anum = acct.account_number
+        bal = await acct.get_balance()
+        print(f'--- Account {anum} Balances ---')
+        print(bal)
+
+        print(f'--- Account {anum} Positions ---')
+        positions = await acct.get_positions()
+        for pos in positions:
+            print(f'{pos["symbol"]:30s} {pos["quantity"]:3d} {pos["average-open-price"]:8s} {pos["close-price"]}')
+
+        print(f'--- Account {anum} Transaction History ---')
+        history = await acct.get_history()
+        for h in history:
+            # print(f'{h["executed-at"]:20s} {h["action"]:15s} {h["underlying-symbol"]:6s} {h["quantity"]} {h["price"]}')
+            print(f'{h["executed-at"]:32s} {h["description"]}')
 
     orders = await Order.get_remote_orders(session, acct)
-    LOGGER.info('Number of active orders: %s', len(orders))
+    print(f'Number of active orders: {len(orders)}')
 
+    await streamer.add_data_sub(sub_values)
+
+    print('Monitoring /ES updates...')
+    async for item in streamer.listen():
+        LOGGER.info('Received item: %s' % item.data)
+
+
+async def execute_order(acct, session):
     # Execute an order
-
     details = OrderDetails(
         type=OrderType.LIMIT,
         price=Decimal(400),
@@ -45,7 +71,7 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     new_order = Order(details)
 
     opt = Option(
-        ticker='AKS',
+        ticker='F',
         quantity=1,
         expiry=get_third_friday(date.today()),
         strike=Decimal(3),
@@ -57,16 +83,15 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     res = await acct.execute_order(new_order, session, dry_run=True)
     LOGGER.info('Order executed successfully: %s', res)
 
+
+async def get_options_chain(symbol, session):
     # Get an options chain
-    undl = underlying.Underlying('AKS')
-
-    chain = await option_chain.get_option_chain(session, undl)
-    LOGGER.info('Chain strikes: %s', chain.get_all_strikes())
-
-    await streamer.add_data_sub(sub_values)
-
-    async for item in streamer.listen():
-        LOGGER.info('Received item: %s' % item.data)
+    try:
+        undl = underlying.Underlying(symbol)
+        chain = await option_chain.get_option_chain(session, undl)
+        LOGGER.info('Chain strikes: %s', chain.get_all_strikes())
+    except Exception:
+        LOGGER.error(f'Could not get options for {symbol}')
 
 
 def get_third_friday(d):
@@ -83,7 +108,13 @@ def get_third_friday(d):
 
 
 def main():
-    tasty_client = tasty_session.create_new_session(environ.get('TW_USER', ""), environ.get('TW_PASSWORD', ""))
+    user = environ.get('TW_USER', '')
+    password = environ.get('TW_PASSWORD', '')
+    if user == '':
+        LOGGER.exception('Please provide username')
+    if password == '':
+        LOGGER.exception('Please provide password')
+    tasty_client = tasty_session.create_new_session(user, password)
 
     streamer = DataStreamer(tasty_client)
     LOGGER.info('Streamer token: %s' % streamer.get_streamer_token())
@@ -96,7 +127,7 @@ def main():
     finally:
         # find all futures/tasks still running and wait for them to finish
         pending_tasks = [
-            task for task in asyncio.Task.all_tasks() if not task.done()
+            task for task in asyncio.all_tasks() if not task.done()
         ]
         loop.run_until_complete(asyncio.gather(*pending_tasks))
         loop.close()

--- a/tastyworks/models/option_chain.py
+++ b/tastyworks/models/option_chain.py
@@ -85,4 +85,7 @@ async def _get_tasty_option_chain_data(session, underlying) -> Dict:
         resp = await response.json()
 
         # NOTE: Have not seen an example with more than 1 item. No idea what that would be.
-        return resp['data']['items'][0]
+        if 'items' in resp['data'] and len(resp['data']['items']) > 0:
+            return resp['data']['items'][0]
+        else:
+            raise Exception(f'Empty option chain data for symbol {underlying.ticker}')


### PR DESCRIPTION
# Problem addressed

Some of the tastyworks endpoints need to be paginated. this PR adds pagination for the transactions (history) endpoint.

I refactored tastyworks/models/trading_account.py to save the session into the account object. It seemed cleaner to me. If you don't like it, I understand rejecting the PR. But feel free to use what I learned about history pagination in your own way.

# Solution

Use HTTP GET request arguments "start-at", "end-at", "per-page", "page-offset"
Use HTTP GET response parameters "pagination" and "total-pages"

# Checklist

- [x] PR commits have been squashed
- [x] All tests pass
- [x] Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
