### PR TITLE
Adding a Greeks class

### DIFF
--- a/tastyworks/example.py
+++ b/tastyworks/example.py
@@ -31,7 +31,7 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     }
 
     accounts = await TradingAccount.get_remote_accounts(session)
-    acct = accounts[1]
+    acct = accounts[0]
     LOGGER.info('Accounts available: %s', accounts)
 
     orders = await Order.get_remote_orders(session, acct)
@@ -124,13 +124,12 @@ def main():
     except Exception:
         LOGGER.exception('Exception in main loop')
     finally:
-        pass
-        # # find all futures/tasks still running and wait for them to finish
-        # pending_tasks = [
-        #     task for task in asyncio.Task.all_tasks() if not task.done()
-        # ]
-        # loop.run_until_complete(asyncio.gather(*pending_tasks))
-        # loop.close()
+        # find all futures/tasks still running and wait for them to finish
+        pending_tasks = [
+            task for task in asyncio.Task.all_tasks() if not task.done()
+        ]
+        loop.run_until_complete(asyncio.gather(*pending_tasks))
+        loop.close()
 
 
 if __name__ == '__main__':

--- a/tastyworks/example.py
+++ b/tastyworks/example.py
@@ -14,6 +14,7 @@ from tastyworks.models.trading_account import TradingAccount
 from tastyworks.models.underlying import UnderlyingType
 from tastyworks.streamer import DataStreamer
 from tastyworks.tastyworks_api import tasty_session
+from tastyworks.models.greeks import Greeks
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     }
 
     accounts = await TradingAccount.get_remote_accounts(session)
-    acct = accounts[0]
+    acct = accounts[1]
     LOGGER.info('Accounts available: %s', accounts)
 
     orders = await Order.get_remote_orders(session, acct)
@@ -45,10 +46,10 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     new_order = Order(details)
 
     opt = Option(
-        ticker='AKS',
+        ticker='SPY',
         quantity=1,
         expiry=get_third_friday(date.today()),
-        strike=Decimal(3),
+        strike=Decimal(500),
         option_type=OptionType.CALL,
         underlying_type=UnderlyingType.EQUITY
     )
@@ -58,10 +59,39 @@ async def main_loop(session: TastyAPISession, streamer: DataStreamer):
     LOGGER.info('Order executed successfully: %s', res)
 
     # Get an options chain
-    undl = underlying.Underlying('AKS')
-
+    undl = underlying.Underlying('SPY')
     chain = await option_chain.get_option_chain(session, undl)
     LOGGER.info('Chain strikes: %s', chain.get_all_strikes())
+
+    # Get all expirations for the options for the above equity symbol
+    exp = chain.get_all_expirations()
+
+    # Choose the next expiration as an example & fetch the entire options chain for that expiration (all strikes)
+    next_exp = exp[0]
+    chain_next_exp = await option_chain.get_option_chain(session, undl, next_exp)
+    options = []
+    for option in chain_next_exp.options:
+        options.append(option)
+
+    # Get the greeks data for all option symbols via the streamer by subscribing
+    options_symbols = [options[x].symbol_dxf for x in range(len(options))]
+    streamer_list = {"Greeks": options_symbols}
+    await streamer.add_data_sub(streamer_list)
+    greeks_data = []
+
+    async for item in streamer.listen():
+        # This is where you manipulate incoming streamer data
+        greeks_data.extend(item.data)
+        if len(greeks_data) >= len(streamer_list['Greeks']):
+            break  # Stops the async for item in streamer.listen() loop after receiving all the data
+
+    for data in greeks_data:
+        gd = Greeks().from_streamer_dict(data)
+        # gd = Greeks(kwargs=data)
+        idx_match = [options[x].symbol_dxf for x in range(len(options))].index(gd.symbol)
+        options[idx_match].greeks = gd
+        LOGGER.info('> Symbol: {}\tPrice: {}\tDelta {}'.format(gd.symbol, gd.price, gd.delta))
+        # print('> Option with Greeks:\n', options[idx_match])
 
     await streamer.add_data_sub(sub_values)
 
@@ -94,12 +124,13 @@ def main():
     except Exception:
         LOGGER.exception('Exception in main loop')
     finally:
-        # find all futures/tasks still running and wait for them to finish
-        pending_tasks = [
-            task for task in asyncio.Task.all_tasks() if not task.done()
-        ]
-        loop.run_until_complete(asyncio.gather(*pending_tasks))
-        loop.close()
+        pass
+        # # find all futures/tasks still running and wait for them to finish
+        # pending_tasks = [
+        #     task for task in asyncio.Task.all_tasks() if not task.done()
+        # ]
+        # loop.run_until_complete(asyncio.gather(*pending_tasks))
+        # loop.close()
 
 
 if __name__ == '__main__':

--- a/tastyworks/models/greeks.py
+++ b/tastyworks/models/greeks.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from datetime import datetime
+
+
+@dataclass
+class Greeks(object):
+    symbol: str = None
+    index: str = None
+    datetime: datetime = None
+    price: Decimal = None
+    volatility: Decimal = None
+    delta: Decimal = None
+    gamma: Decimal = None
+    theta: Decimal = None
+    rho: Decimal = None
+    vega: Decimal = None
+
+    # kwargs: field(default_factory=dict) = None
+
+    # def __post_init__(self):
+    #     if self.kwargs:
+    #         [setattr(self, k, v) for k, v in self.kwargs.items()]
+
+    def from_streamer_dict(self, input_dict: dict):
+        """
+        imports the Greeks data from a dictionary pulled from subscribed streamer data
+            sub_greeks = {"Greeks": [".SPY210419P410"]}
+            await streamer.add_data_sub(sub_greeks)
+
+        Args:
+            input_dict (dict): dictionary from the streamer containing the greeks data for one options symbol
+
+        """
+        self.symbol = input_dict.get('eventSymbol')
+        self.index = input_dict.get('index')
+        self.datetime = datetime.fromtimestamp(input_dict.get('time')/1000.0)  # timestamp comes in ms
+        self.price = Decimal(str(input_dict.get('price')))
+        self.volatility = Decimal(str(input_dict.get('volatility')))
+        self.delta = Decimal(str(input_dict.get('delta')))
+        self.gamma = Decimal(str(input_dict.get('gamma')))
+        self.theta = Decimal(str(input_dict.get('theta')))
+        self.rho = Decimal(str(input_dict.get('rho')))
+        self.vega = Decimal(str(input_dict.get('vega')))
+
+        return self

--- a/tastyworks/models/option.py
+++ b/tastyworks/models/option.py
@@ -2,7 +2,7 @@ from datetime import date
 from decimal import Decimal
 from enum import Enum
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from tastyworks.models.security import Security
 from tastyworks.models.underlying import UnderlyingType

--- a/tastyworks/models/option.py
+++ b/tastyworks/models/option.py
@@ -2,10 +2,11 @@ from datetime import date
 from decimal import Decimal
 from enum import Enum
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from tastyworks.models.security import Security
 from tastyworks.models.underlying import UnderlyingType
+from tastyworks.models.greeks import Greeks
 
 
 class OptionType(Enum):
@@ -20,7 +21,14 @@ class Option(Security):
     strike: Decimal
     option_type: OptionType
     underlying_type: UnderlyingType
+    greeks: Greeks = None
     quantity: int = 1
+    symbol_occ: str = None
+    symbol_dxf: str = None
+
+    def __post_init__(self):
+        self.symbol_occ = self.get_occ2010_symbol()
+        self.symbol_dxf = self.get_dxfeed_symbol()
 
     def _get_underlying_type_string(self, underlying_type: UnderlyingType):
         if underlying_type == UnderlyingType.EQUITY:


### PR DESCRIPTION
# Problem addressed

**Greeks** class missing to hold all the greeks for a specific option symbol.

# Solution

- Created a Greeks class
- Added a greeks field in the Option class.
- Added 'symbol_occ' and 'symbol_dxf' in the Options class to hold the two symbols variations by default at __post_init__. It seems that it'll be simpler to just have them in the object at initialization rather than having to call for their creation because  you can't really do anything on the option itself unless you have these symbols so why force the user to have to create the (you need it for greeks, for subscription, for trade, etc.).
- Updated the example to include an example of the Greeks (this may be better done in the Options class with a get_greeks() method.

# Checklist

- PR commits have been squashed
- All tests pass
- Code adheres to [contributing guidelines](https://github.com/boyan-soubachov/tastyworks_api/blob/master/CONTRIBUTING.md)
